### PR TITLE
event 시간이 1970년 1월 1일로 보여지는 버그 수정

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -51,13 +51,11 @@ const Inner = connectToFlags(FLAGS.CAN_LIST_NODE)(
             <div className="co-sysevent__header">
               <div className="co-sysevent__subheader">
                 <ResourceLink className="co-sysevent__resourcelink" kind={obj.kind} namespace={obj.namespace} name={obj.name} title={obj.uid} />
-                {/* <Timestamp timestamp={lastTimestamp} /> */}
                 <Timestamp timestamp={lastTimestamp} t={t} />
               </div>
               <div className="co-sysevent__details">
                 {!HDCModeFlag && (
                   <small className="co-sysevent__source">
-                    {/* {t('CONTENT:GENERATEDFROM')} <span>{source.component}</span> */}
                     {t('ADDITIONAL:GENERATEDFROM', { something: source.component })}
                     {source.component === 'kubelet' && <span> on {flags[FLAGS.CAN_LIST_NODE] ? <Link to={resourcePathFromModel(NodeModel, source.host)}>{source.host}</Link> : <React.Fragment>{source.host}</React.Fragment>}</span>}
                   </small>
@@ -65,7 +63,6 @@ const Inner = connectToFlags(FLAGS.CAN_LIST_NODE)(
                 {count > 1 && (
                   <small className="co-sysevent__count text-secondary">
                     {count} {t('CONTENT:TIMESINTHELAST')}
-                    {/* <Timestamp timestamp={firstTimestamp} simple={true} omitSuffix={true} /> */}
                     <Timestamp timestamp={firstTimestamp} simple={true} omitSuffix={true} t={t} />
                   </small>
                 )}

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -104,7 +104,7 @@ class SysEvent extends React.Component {
   }
 
   render() {
-    const { index, style, reason, message, source, metadata, firstTimestamp, lastTimestamp, count, involvedObject: obj, t } = this.props;
+    const { index, style, reason, message, source, metadata, firstTimestamp, lastTimestamp, eventTime, count, involvedObject: obj, t } = this.props;
     const klass = classNames('co-sysevent', { 'co-sysevent--error': categoryFilter('error', this.props) });
     const tooltipMsg = `${reason} (${obj.kind.toLowerCase()})`;
 
@@ -119,7 +119,7 @@ class SysEvent extends React.Component {
     return (
       <div style={style}>
         <CSSTransition mountOnEnter={true} appear={shouldAnimate} in exit={false} timeout={timeout} classNames="slide">
-          {status => <Inner klass={klass} status={status} tooltipMsg={tooltipMsg} obj={obj} firstTimestamp={firstTimestamp} lastTimestamp={lastTimestamp} count={count} message={message} source={source} width={style.width} t={t} />}
+          {status => <Inner klass={klass} status={status} tooltipMsg={tooltipMsg} obj={obj} firstTimestamp={firstTimestamp || eventTime} lastTimestamp={lastTimestamp || eventTime} count={count} message={message} source={source} width={style.width} t={t} />}
         </CSSTransition>
       </div>
     );


### PR DESCRIPTION
### What
Home > Event 메뉴에서 일부 event 시간이 1970년 1월 1일로 보여지는 버그 수정

### Why
event 객체의 firstTimestamp, lastTimestamp가 deprecated됨에 따라 그 이후에 만들어진 event 객체는 eventTime에 시간을 넣어주고 있음
UI에서는 firstTimestamp 필드를 참조하고 있기에 해당 필드가 null로 오는 event는 timestamp를 new Date로 변환하는 과정에서 1970년 1월 1일로 변환되어 보여짐
참고: IMS 244000 [HCDC] 이벤트 시간이 1970년 1월 1일로 찍히는 현상

### How
OR 연산자를 통해 firstTimestamp, lastTimestamp 값이 null인 경우, eventTime 필드를 이용하도록 수정