### PR TITLE
[bugfix] service class name에 'z'가 들어갈 때 나는 에러 우회처리로 해결

### DIFF
--- a/frontend/public/components/service-instances/create-service-instance.jsx
+++ b/frontend/public/components/service-instances/create-service-instance.jsx
@@ -169,7 +169,9 @@ const withServiceInstanceForm = SubForm =>
       if (!selectedClass) {
         return;
       }
-      coFetch(`/api/kubernetes/apis/${k8sModels.TemplateModel.apiGroup}/${k8sModels.TemplateModel.apiVersion}/namespaces/${this.state.namespace}/templates/${selectedClass.name}`)
+      /* selectedClass.name에 'z'가 들어갈 시 IMS244619문제가 있어서 대체방안으로 selectedClass.spec.externalID를 name으로 사용함*/
+      // coFetch(`/api/kubernetes/apis/${k8sModels.TemplateModel.apiGroup}/${k8sModels.TemplateModel.apiVersion}/namespaces/${this.state.namespace}/templates/${selectedClass.name}`)
+      coFetch(`/api/kubernetes/apis/${k8sModels.TemplateModel.apiGroup}/${k8sModels.TemplateModel.apiVersion}/namespaces/${this.state.namespace}/templates/${selectedClass.spec.externalID}`)
         .then(res => res.json())
         .then(res => {
           let paramList = res.parameters.map(function (parm) {


### PR DESCRIPTION
* IMS 244691 (브랜치 IMS 번호 오타남. 244691이 맞음)
* Service Class이름에 z가 들어갈 경우 서버에선 z가 'z7az'로 변경되어 저장되고 해당 이름으로 서버 api사용할 경우 오류 발생. PM회의를 통해 임시방안으로 name 대신 externalID를 사용하여 조회하는 것으로 결정 됨. 