### PR TITLE
서비스콜 호출 시, 404 에러에 대한 예외 처리 추가

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -50,6 +50,12 @@ const validateStatus = (response, url) => {
     return response;
   }
 
+  if (response.status === 404) {
+    const error = new Error('The requested page could not be found.');
+    error.response = response;
+    throw error;
+  }
+
   const contentType = response.headers.get("content-type");
   if (!contentType || contentType.indexOf("json") === -1) {
     const error = new Error(response.statusText);


### PR DESCRIPTION
### What
서비스콜의 response로 404 에러가 발생하는 상황 예외 처리 추가
('The requested page could not be found.' 메시지로 Error 발생 시킴)

### Why
서비스콜로 발생한 404 에러는 특별한 동작을 하지 않아 사용자가 에러가 발생했음을 인지하기가 어려움
(ex. CRD로 정의한 리소스를 namespace 값 없이 create 서비스콜 호출 시, 404 page not found 에러 발생
=> 그러나 사용자 입장에서는 create 버튼은 눌렀으나 아무 동작이 없는 상황)
참고: **IMS 225902**

### How
co-fetch.js 파일의 validateStatus 함수에서 status가 404일 경우, 위 에러 메시지로 에러를 throw하도록 예외 처리 추가
(throw된 에러는, why 단락 예시의 경우, edit-yaml.jsx 파일 내 EditYAML component의 save 함수에서 action(k8sCreate) 서비스콜에 대한 에러로 catch됨)

co-fetch.js 파일: 서비스콜 호출 관련 util 함수들을 포함
validateStatus 함수: co-fetch.js 파일의 coFetch 함수를 통해 호출되는 서비스콜의 status를 확인하여 예외 처리하는 함수